### PR TITLE
Removing parsing of react and react-router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 static/
 npm-debug.log
+.idea/

--- a/app/index.jsx
+++ b/app/index.jsx
@@ -2,7 +2,7 @@ var React = require('react')
   , Router = require('react-router');
 
 var App = require('./components/App')
-  , Hello = require('./components/Hello')
+  , Hello = require('./components/Hello');
 
 require('./styles/index.scss');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,9 @@
 var webpack = require('webpack')
-  , path = require('path');
+  , path = require('path')
+  , node_modules = path.resolve(__dirname, 'node_modules')
+  , reactPath = path.resolve(node_modules, 'react/dist/react.min.js')
+  , reactRouterPath = path.resolve(node_modules, 'react-router/umd/ReactRouter.min.js')
+  , reactLibPath = path.resolve(node_modules, 'react/lib');
 
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
@@ -28,6 +32,7 @@ module.exports = {
       {
         test: /\.jsx$/,
         loaders: [ 'react-hot', 'babel'],
+        exclude: /node_modules/,
         include: path.join(__dirname, 'app')
       },
       {
@@ -41,7 +46,8 @@ module.exports = {
         )
       },
       { test: /\.css$/, loader: 'style-loader!css-loader' }
-    ]
+    ],
+    noParse: [reactPath, reactRouterPath, reactLibPath]
   },
   plugins: [
     new ExtractTextPlugin('[name].css'),
@@ -50,6 +56,12 @@ module.exports = {
   ],
   resolve: {
     modulesDirectories: [ 'app', 'app/styles/components', 'node_modules' ],
-    extensions: ['', '.js', '.json', '.jsx', '.css', '.scss']
+    extensions: ['', '.js', '.json', '.jsx', '.css', '.scss'],
+    alias: {
+      'react/lib': reactLibPath,
+      'react': reactPath,
+      'react-router': reactRouterPath
+
+    }
   }
 };


### PR DESCRIPTION
## Purpose

Currently,  we are parsing through both `react` and `react-router`. This is causing a slower build to occur. With this feature we are only pointing to the minified versions of `react` and `react-router`. This optimization cuts off about 1s and provides a cleaner build log. 
