### PR TITLE
Remove unneeded HMR plugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,6 @@ module.exports = {
       production: isProd
     })
   ] : [
-    new webpack.HotModuleReplacementPlugin(),
     new webpack.NoErrorsPlugin(),
     new HtmlWebpackPlugin({
       title: package.name,


### PR DESCRIPTION
Got fiddling around and noticed an error being thrown whenever a hot update was applied to a component:

![webpack-react-skeleton](https://cloud.githubusercontent.com/assets/3008729/11748524/b5244914-9ff6-11e5-87e3-693cd13efdcc.jpg)

Looks like Webpack's getting the HMR plugin twice -- once from calling `webpackdevserver --hot` on the command line and again explicitly in `webpack.config`. Removing the HMR plugin from the config file stopped the error. 

Not a showstopper by any stretch, just noticed it and figured I'd send a fix. Thanks for sharing the project. It's been helpful! 

PS: I'm still a noob at PRs and such, so I hope I did this right!
